### PR TITLE
prevent duplicate donors

### DIFF
--- a/src/main/java/com/example/donationdbjavaserver/services/DonorService.java
+++ b/src/main/java/com/example/donationdbjavaserver/services/DonorService.java
@@ -74,7 +74,12 @@ public class DonorService{
 	
 	@PostMapping("/api/donors")
 	public Donor createDonor(@RequestBody Donor donor) {
-		return donorRepository.save(donor);
+		try {
+			Donor existingDonor = donorRepository.findDonorByName(donor.getDonorName()).get(0);
+			return existingDonor;
+		} catch (Exception e) {
+			return donorRepository.save(donor);
+		}
 	}
 	
 	@PutMapping("/api/donor/{donorId}")


### PR DESCRIPTION
check if donor name exists before creating new donor.  if it does, return existing donor.